### PR TITLE
Simple envsubst to allow environment variables

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+envsubst~=0.1.5
 yamale~=3.0
-
 pre-commit~=2.12

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     ],
     packages=find_packages(exclude=('tests*', 'testing*')),
     install_requires=[
+        'envsubst~=0.1.5',
         'yamale~=3.0',
     ],
     python_requires='>=3.6.1',

--- a/yamale_validate/yamale_validate.py
+++ b/yamale_validate/yamale_validate.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 from typing import List
+from envsubst import envsubst
 
 
 def main(argv=None):
@@ -51,7 +52,7 @@ def main(argv=None):
             data = yamale.make_data(path=file_path, parser=args.parser)
 
             try:
-                schema_path = args.schema if os.path.isabs(args.schema) else os.path.join(os.path.dirname(file_path), args.schema)
+                schema_path = envsubst(args.schema) if os.path.isabs(envsubst(args.schema)) else os.path.join(os.path.dirname(file_path), envsubst(args.schema))
                 if file_path == schema_path:
                     continue
 


### PR DESCRIPTION
Tentative workaround to https://github.com/k-ogawa-1988/yamale-pre-commit/issues/1

```
  - repo: https://github.com/chickenandpork/yamale-pre-commit
    rev: 23d22fe
    hooks:
      - id: yamale-validate
        files: values.yaml
        args:
          - '--no-strict'
          - '-s'
          - ${PWD}/tools/pre-commit/yamale-schema.yaml
```

Fairly unsophisticated use of `envsubst` around the schema did this for me; I'm not sure if this is of benefit to others, but I wanted to share and see if it can be waintained in the upstream repo.